### PR TITLE
CORE-8456: support UsesVolumes method on containers, steps, and jobs

### DIFF
--- a/container.go
+++ b/container.go
@@ -58,3 +58,11 @@ func (c *Container) WorkingDirectory() string {
 	}
 	return c.WorkingDir
 }
+
+// UsesVolumes returns a boolean value which indicates if a container uses host-mounted volumes
+func (c *Container) UsesVolumes() bool {
+	if len(c.Volumes) > 0 {
+		return true
+	}
+	return false
+}

--- a/container_test.go
+++ b/container_test.go
@@ -126,6 +126,40 @@ func TestStepContainerVolumes(t *testing.T) {
 	}
 }
 
+func TestUsesVolumes(t *testing.T) {
+	s := inittests(t)
+	container := s.Steps[0].Component.Container
+	if !container.UsesVolumes() {
+		t.Error("The container UsesVolumes method was false when it should have been true.")
+	}
+
+	step := s.Steps[0]
+	if !step.UsesVolumes() {
+		t.Error("The step UsesVolumes method was false when it should have been true.")
+	}
+
+	if !s.UsesVolumes() {
+		t.Error("The job UsesVolumes method was false when it should have been true.")
+	}
+}
+
+func TestNotUsesVolumes(t *testing.T) {
+	s := inittestsFile(t, "test/no_volumes_submission.json")
+	container := s.Steps[0].Component.Container
+	if container.UsesVolumes() {
+		t.Error("The container UsesVolumes method was false when it should have been true.")
+	}
+
+	step := s.Steps[0]
+	if step.UsesVolumes() {
+		t.Error("The step UsesVolumes method was false when it should have been true.")
+	}
+
+	if s.UsesVolumes() {
+		t.Error("The job UsesVolumes method was false when it should have been true.")
+	}
+}
+
 func TestStepContainerDevices(t *testing.T) {
 	s := inittests(t)
 	devices := s.Steps[0].Component.Container.Devices

--- a/jobs.go
+++ b/jobs.go
@@ -349,6 +349,16 @@ func (s *Job) FormatUserGroups() string {
 	return submitfile.FormatList(s.UserGroups)
 }
 
+// UsesVolumes returns a boolean value which indicates if any step of a job uses host-mounted volumes
+func (s *Job) UsesVolumes() bool {
+	for _, step := range s.Steps {
+		if step.UsesVolumes() {
+			return true
+		}
+	}
+	return false
+}
+
 // FileMetadata describes a unit of metadata that should get associated with
 // all of the files associated with the job submission.
 type FileMetadata struct {

--- a/step.go
+++ b/step.go
@@ -56,6 +56,11 @@ func (s *Step) IsBackwardsCompatible() bool {
 		strings.HasPrefix(img, "gims.iplantcollaborative.org:5000/backwards-compat")
 }
 
+// UsesVolumes returns a boolean value which indicates if a step uses host-mounted volumes
+func (s *Step) UsesVolumes() bool {
+	return s.Component.Container.UsesVolumes()
+}
+
 // Executable returns a string containing the executable path as it gets placed
 // inside the docker command-line.
 func (s *Step) Executable() string {

--- a/test/no_volumes_submission.json
+++ b/test/no_volumes_submission.json
@@ -1,0 +1,108 @@
+{
+    "description":"this is a description",
+    "email":"wregglej@iplantcollaborative.org",
+    "name":"Word Count analysis1@@",
+    "username":"test@this is a test",
+    "app_id":"c7f05682-23c8-4182-b9a2-e09650a5f49b",
+    "user_id": "00000000-0000-0000-0000-000000000000",
+    "user_groups": ["groups:foo", "groups:bar", "groups:baz"],
+    "steps":[
+        {
+            "component":{
+                "container":{
+                    "name" : "test-name",
+                    "network_mode" : "none",
+                    "cpu_shares" : 2048,
+                    "memory_limit" : 2048,
+                    "entrypoint" : "/bin/true",
+                    "id":"16fd2a16-3ac6-11e5-a25d-2fa4b0893ef1",
+                    "image":{
+                        "id":"fc210a84-f7cd-4067-939c-a68ec3e3bd2b",
+                        "url":"https://registry.hub.docker.com/u/discoenv/backwards-compat",
+                        "tag":"latest",
+                        "name":"gims.iplantcollaborative.org:5000/backwards-compat"
+                    },
+                    "working_directory" : "/work"
+                },
+                "type":"executable",
+                "name":"wc_wrapper.sh",
+                "location":"/usr/local3/bin/wc_tool-1.00",
+                "description":"Word Count"
+            },
+            "environment":{
+                "food" : "banana",
+                "foo" : "bar"
+            },
+            "config":{
+                "input":[
+                    {
+                        "id":"2f58fce9-8183-4ab5-97c4-970592d1c35a",
+                        "multiplicity":"single",
+                        "name":"Acer-tree.txt",
+                        "property":"Acer-tree.txt",
+                        "retain":true,
+                        "type":"FileInput",
+                        "value":"/iplant/home/wregglej/Acer-tree.txt"
+                    }
+                ],
+                "output":[
+                    {
+                        "multiplicity":"single",
+                        "name":"wc_out.txt",
+                        "property":"wc_out.txt",
+                        "qual-id":"67781636-854a-11e4-b715-e70c4f8db0dc_e7721c78-56c9-41ac-8ff5-8d46093f1fb1",
+                        "retain":true,
+                        "type":"File"
+                    },
+                    {
+                        "multiplicity":"collection",
+                        "name":"logs",
+                        "property":"logs",
+                        "type":"File",
+                        "retain":true
+                    }
+                ],
+                "params":[
+                    {
+                        "id":"e7721c78-56c9-41ac-8ff5-8d46093f1fb1",
+                        "name":"param0",
+                        "order":2,
+                        "value":"wc_out.txt"
+                    },
+                    {
+                        "id":"2f58fce9-8183-4ab5-97c4-970592d1c35a",
+                        "name":"param1",
+                        "order":1,
+                        "value":"Acer-tree.txt"
+                    }
+                ]
+            },
+            "stdin" : "/path/to/stdin",
+            "stdout" : "/path/to/stdout",
+            "stderr" : "/path/to/stderr",
+            "log-file" : "log-file-name",
+            "type":"condor"
+        }
+    ],
+    "file-metadata" : [
+      {
+        "attr" : "attr1",
+        "value" : "value1",
+        "unit" : "unit1"
+      },
+      {
+        "attr" : "attr2",
+        "value" : "value2",
+        "unit" : "unit2"
+      }
+    ],
+    "create_output_subdir":true,
+    "request_type":"submit",
+    "app_description":"this is an app description",
+    "output_dir":"/iplant/home/wregglej/analyses/Word_Count_analysis1-2015-09-17-21-42-20.9",
+    "wiki_url":"https://pods.iplantcollaborative.org/wiki/display/DEapps/WordCount",
+    "uuid":"07b04ce2-7757-4b21-9e15-0b4c2f44be26",
+    "notify":true,
+    "execution_target":"condor",
+    "app_name":"Word Count"
+}


### PR DESCRIPTION
This, assuming I've written it right, can be brought into condor-launcher and then used to add clauses to the `requirements` in the condor submit file so that if a job needs host volumes, it specifies as much. In practice, the condor-launcher change will be accompanied by a change to the condor nodes which adds the appropriate classads on their end as well, so that jobs needing the NFS mounts can be appropriately routed.