### PR TITLE
Remove --config flag for input and output jobs

### DIFF
--- a/io.go
+++ b/io.go
@@ -69,7 +69,6 @@ func (i *StepInput) Arguments(username string, metadata []FileMetadata) []string
 		"get",
 		"--user", username,
 		"--source", path,
-		"--config", "/configs/irods-config",
 	}
 	for _, m := range MetadataArgs(metadata).FileMetadataArguments() {
 		args = append(args, m)

--- a/jobs.go
+++ b/jobs.go
@@ -346,7 +346,6 @@ func (s *Job) FinalOutputArguments() []string {
 	retval := []string{
 		"put",
 		"--user", s.Submitter,
-		"--config", "/configs/irods-config",
 		"--destination", dest,
 	}
 	for _, m := range MetadataArgs(s.FileMetadata).FileMetadataArguments() {

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -608,7 +608,6 @@ func TestFinalOutputArguments(t *testing.T) {
 	expected := []string{
 		"put",
 		"--user", "test_this_is_a_test",
-		"--config", "/configs/irods-config",
 		"--destination", fmt.Sprintf("%s", outputdir),
 		"-m", "attr1,value1,unit1",
 		"-m", "attr2,value2,unit2",
@@ -624,7 +623,6 @@ func TestFinalOutputArguments(t *testing.T) {
 	expected = []string{
 		"put",
 		"--user", "test_this_is_a_test",
-		"--config", "/configs/irods-config",
 		"--destination", fmt.Sprintf("%s", outputdir),
 		"-m", "attr1,value1,unit1",
 		"-m", "attr2,value2,unit2",

--- a/step_test.go
+++ b/step_test.go
@@ -352,7 +352,6 @@ func TestInputArguments(t *testing.T) {
 		"get",
 		"--user", "testuser",
 		"--source", "/iplant/home/wregglej/Acer-tree.txt",
-		"--config", "/configs/irods-config",
 		"-m", "attr1,value1,unit1",
 		"-m", "attr2,value2,unit2",
 		"-m", "ipc-analysis-id,c7f05682-23c8-4182-b9a2-e09650a5f49b,UUID",


### PR DESCRIPTION
This is needed for when porklock reads the iRODS config from Vault. This shouldn't affect any existing builds until I update the vendored version of model in road-runner.