### PR TITLE
CORE-8886 Add `pids_limit` to the job model's `Container` struct.

### DIFF
--- a/container.go
+++ b/container.go
@@ -49,6 +49,7 @@ type Container struct {
 	MinMemoryLimit int64          `json:"min_memory_limit"` // The minimum the container needs.
 	MinCPUCores    int            `json:"min_cpu_cores"`    // The minimum number of cores the container needs.
 	MinDiskSpace   int64          `json:"min_disk_space"`   // The minimum amount of disk space that the container needs.
+	PIDsLimit      int64          `json:"pids_limit"`
 	Image          ContainerImage `json:"image"`
 	EntryPoint     string         `json:"entrypoint"`
 	WorkingDir     string         `json:"working_directory"`


### PR DESCRIPTION
This PR will add a `PIDsLimit` field to the job model's `Container` struct.
This field is parsed from a job's `pids_limit` JSON field.

This will allow [road-runner](https://github.com/cyverse-de/road-runner/) to add a `pids_limit` field to the `docker-compose.yml` file on the job's Condor node.

Note: The [apps](https://github.com/cyverse-de/apps) service is already submitting a tool's `pids_limit` to the jobs services, but in order for this field to be available to [road-runner](https://github.com/cyverse-de/road-runner/), the [condor-launcher](https://github.com/cyverse-de/condor-launcher) and [jex-adapter](https://github.com/cyverse-de/jex-adapter) services will need to be updated with the new model as well.