### PR TITLE
CORE-9100 Update ExcludeArguments to return a list of paths.

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -274,8 +274,7 @@ func (s *Job) Outputs() []StepOutput {
 	return outputs
 }
 
-// ExcludeArguments returns a string containing the command-line settings for
-// porklock that tell it which files to skip.
+// ExcludeArguments returns a list of paths that should not upload as outputs.
 func (s *Job) ExcludeArguments() []string {
 	var paths []string
 	for _, input := range s.Inputs() {
@@ -294,12 +293,8 @@ func (s *Job) ExcludeArguments() []string {
 	if !s.ArchiveLogs {
 		paths = append(paths, "logs")
 	}
-	retval := []string{}
-	if len(paths) > 0 {
-		retval = append(retval, "--exclude")
-		retval = append(retval, strings.Join(paths, ","))
-	}
-	return retval
+
+	return paths
 }
 
 // AddRequiredMetadata adds any required AVUs that are required but are missing
@@ -341,7 +336,7 @@ func (s *Job) AddRequiredMetadata() {
 // FinalOutputArguments returns a string containing the arguments passed to
 // porklock for the final output operation, which transfers all files back into
 // iRODS.
-func (s *Job) FinalOutputArguments() []string {
+func (s *Job) FinalOutputArguments(excludeFilePath string) []string {
 	dest := s.OutputDirectory()
 	retval := []string{
 		"put",
@@ -351,8 +346,8 @@ func (s *Job) FinalOutputArguments() []string {
 	for _, m := range MetadataArgs(s.FileMetadata).FileMetadataArguments() {
 		retval = append(retval, m)
 	}
-	for _, e := range s.ExcludeArguments() {
-		retval = append(retval, e)
+	if excludeFilePath != "" {
+		retval = append(retval, "--exclude", excludeFilePath)
 	}
 	if s.SkipParentMetadata {
 		retval = append(retval, "--skip-parent-meta")

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -532,25 +532,25 @@ func TestOutputs(t *testing.T) {
 func TestExcludeArguments(t *testing.T) {
 	s := inittests(t)
 	actual := s.ExcludeArguments()
-	expected := []string{"--exclude", "foo,bar,baz,blippy"}
+	expected := []string{"foo", "bar", "baz", "blippy"}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("ExcludeArguments() returned:\n\t%#vinstead of:\n\t%#v", actual, expected)
 	}
 	s.Steps[0].Config.Inputs[0].Retain = false
 	actual = s.ExcludeArguments()
-	expected = []string{"--exclude", "Acer-tree.txt,foo,bar,baz,blippy"}
+	expected = []string{"Acer-tree.txt", "foo", "bar", "baz", "blippy"}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("ExcludeArguments() returned:\n\t%sinstead of:\n\t%s", actual, expected)
 	}
 	s.Steps[0].Config.Outputs[1].Retain = false
 	actual = s.ExcludeArguments()
-	expected = []string{"--exclude", "Acer-tree.txt,/de-app-work/logs/,foo,bar,baz,blippy"}
+	expected = []string{"Acer-tree.txt", "/de-app-work/logs/", "foo", "bar", "baz", "blippy"}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("ExcludeArguments() returned:\n\t%sinstead of:\n\t%s", actual, expected)
 	}
 	s.ArchiveLogs = false
 	actual = s.ExcludeArguments()
-	expected = []string{"--exclude", "Acer-tree.txt,/de-app-work/logs/,foo,bar,baz,blippy,logs"}
+	expected = []string{"Acer-tree.txt", "/de-app-work/logs/", "foo", "bar", "baz", "blippy", "logs"}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("ExcludeArguments() returned:\n\t%sinstead of:\n\t%s", actual, expected)
 	}
@@ -603,7 +603,7 @@ func TestAddRequiredMetadata(t *testing.T) {
 func TestFinalOutputArguments(t *testing.T) {
 	s := inittests(t)
 	s.AddRequiredMetadata()
-	actual := s.FinalOutputArguments()
+	actual := s.FinalOutputArguments("exclude.txt")
 	outputdir := s.OutputDirectory()
 	expected := []string{
 		"put",
@@ -613,13 +613,13 @@ func TestFinalOutputArguments(t *testing.T) {
 		"-m", "attr2,value2,unit2",
 		"-m", "ipc-analysis-id,c7f05682-23c8-4182-b9a2-e09650a5f49b,UUID",
 		"-m", "ipc-execution-id,07b04ce2-7757-4b21-9e15-0b4c2f44be26,UUID",
-		"--exclude", "foo,bar,baz,blippy",
+		"--exclude", "exclude.txt",
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("FinalOutputArguments() returned:\n\t%#v\ninstead of:\n\t%#v", actual, expected)
 	}
 	s.SkipParentMetadata = true
-	actual = s.FinalOutputArguments()
+	actual = s.FinalOutputArguments("exclude.txt")
 	expected = []string{
 		"put",
 		"--user", "test_this_is_a_test",
@@ -628,7 +628,7 @@ func TestFinalOutputArguments(t *testing.T) {
 		"-m", "attr2,value2,unit2",
 		"-m", "ipc-analysis-id,c7f05682-23c8-4182-b9a2-e09650a5f49b,UUID",
 		"-m", "ipc-execution-id,07b04ce2-7757-4b21-9e15-0b4c2f44be26,UUID",
-		"--exclude", "foo,bar,baz,blippy",
+		"--exclude", "exclude.txt",
 		"--skip-parent-meta",
 	}
 	if !reflect.DeepEqual(actual, expected) {


### PR DESCRIPTION
This PR will update the `ExcludeArguments` method to return a list of paths instead of a command-line parameter, and update `FinalOutputArguments` to accept a path to a file that should contain the output of `ExcludeArguments`.

These changes are for compatibility with cyverse-de/porklock#3, so that the job runner will now use `ExcludeArguments` to create a path list file, and the path to that file will be passed to `FinalOutputArguments` for building the `--exclude` parameter.