### PR TITLE
Initial support for configuring interactive apps

### DIFF
--- a/interapps.go
+++ b/interapps.go
@@ -1,0 +1,13 @@
+package model
+
+// InteractiveApps contains the settings needed for interactive apps across all
+// steps in a Job.
+type InteractiveApps struct {
+	ProxyImage  string //The docker image for the reverse proxy that runs on the cluster with the job steps.
+	ProxyName   string //The name of the container for the reverse proxy.
+	FrontendURL string //The URL for the frontend of the application. Will get prefixed with the job id.
+	CASURL      string //The base URL for the CAS server.
+	CASValidate string //The path to the validate endpoint on the CAS server.
+	SSLCertPath string //The path to the SSL cert file on the Condor nodes.
+	SSLKeyPath  string //The path to the SSL key file on the Condor nodes.
+}

--- a/jobs.go
+++ b/jobs.go
@@ -80,7 +80,7 @@ type Job struct {
 	FilterFiles            []string        `json:"filter_files"`       //comes from config, not upstream service
 	Group                  string          `json:"group"`              //untested for now
 	InputTicketsFile       string          `json:"inputs_ticket_list"` //path to a list of inputs with tickets (not from upstream).
-	InteractionApps        InteractiveApps `json:"interactive_apps"`
+	InteractiveApps        InteractiveApps `json:"interactive_apps"`
 	InvocationID           string          `json:"uuid"`
 	IRODSBase              string          `json:"irods_base"`
 	Name                   string          `json:"name"`

--- a/jobs.go
+++ b/jobs.go
@@ -57,51 +57,49 @@ func ExtractJobID(output []byte) []byte {
 
 // Job is a type that contains info that goes into the jobs table.
 type Job struct {
-	AppDescription         string          `json:"app_description"`
-	AppID                  string          `json:"app_id"`
-	AppName                string          `json:"app_name"`
-	ArchiveLogs            bool            `json:"archive_logs"`
-	ID                     string          `json:"id"`
-	BatchID                string          `json:"batch_id"`
-	CASAddr                string          `json:"cas_address"`
-	CondorID               string          `json:"condor_id"`
-	CondorLogPath          string          `json:"condor_log_path"` //comes from config, not upstream service
-	CreateOutputSubdir     bool            `json:"create_output_subdir"`
-	DateSubmitted          time.Time       `json:"date_submitted"`
-	DateStarted            time.Time       `json:"date_started"`
-	DateCompleted          time.Time       `json:"date_completed"`
-	Description            string          `json:"description"`
-	Email                  string          `json:"email"`
-	ExecutionTarget        string          `json:"execution_target"`
-	ExitCode               int             `json:"exit_code"`
-	FailureCount           int64           `json:"failure_count"`
-	FailureThreshold       int64           `json:"failure_threshold"`
-	FileMetadata           []FileMetadata  `json:"file-metadata"`
-	FilterFiles            []string        `json:"filter_files"`       //comes from config, not upstream service
-	Group                  string          `json:"group"`              //untested for now
-	InputTicketsFile       string          `json:"inputs_ticket_list"` //path to a list of inputs with tickets (not from upstream).
-	InteractiveApps        InteractiveApps `json:"interactive_apps"`
-	InvocationID           string          `json:"uuid"`
-	IRODSBase              string          `json:"irods_base"`
-	Name                   string          `json:"name"`
-	NFSBase                string          `json:"nfs_base"`
-	Notify                 bool            `json:"notify"`
-	NowDate                string          `json:"now_date"`
-	OutputDir              string          `json:"output_dir"`         //the value parsed out of the JSON. Use OutputDirectory() instead.
-	OutputDirTicket        string          `json:"output_dir_ticket"`  //the write ticket for output_dir (assumes output_dir is set correctly).
-	OutputTicketFile       string          `json:"output_ticket_list"` //path to the file of the output dest with ticket (not from upstream).
-	OutwardFacingProxyAddr string          `json:"outward_facing_proxy_address"`
-	RequestDisk            string          `json:"request_disk"` //untested for now
-	RequestType            string          `json:"request_type"`
-	RunOnNFS               bool            `json:"run-on-nfs"`
-	SkipParentMetadata     bool            `json:"skip-parent-meta"`
-	Steps                  []Step          `json:"steps"`
-	SubmissionDate         string          `json:"submission_date"`
-	Submitter              string          `json:"username"`
-	Type                   string          `json:"type"`
-	UserID                 string          `json:"user_id"`
-	UserGroups             []string        `json:"user_groups"`
-	WikiURL                string          `json:"wiki_url"`
+	AppDescription     string          `json:"app_description"`
+	AppID              string          `json:"app_id"`
+	AppName            string          `json:"app_name"`
+	ArchiveLogs        bool            `json:"archive_logs"`
+	ID                 string          `json:"id"`
+	BatchID            string          `json:"batch_id"`
+	CondorID           string          `json:"condor_id"`
+	CondorLogPath      string          `json:"condor_log_path"` //comes from config, not upstream service
+	CreateOutputSubdir bool            `json:"create_output_subdir"`
+	DateSubmitted      time.Time       `json:"date_submitted"`
+	DateStarted        time.Time       `json:"date_started"`
+	DateCompleted      time.Time       `json:"date_completed"`
+	Description        string          `json:"description"`
+	Email              string          `json:"email"`
+	ExecutionTarget    string          `json:"execution_target"`
+	ExitCode           int             `json:"exit_code"`
+	FailureCount       int64           `json:"failure_count"`
+	FailureThreshold   int64           `json:"failure_threshold"`
+	FileMetadata       []FileMetadata  `json:"file-metadata"`
+	FilterFiles        []string        `json:"filter_files"`       //comes from config, not upstream service
+	Group              string          `json:"group"`              //untested for now
+	InputTicketsFile   string          `json:"inputs_ticket_list"` //path to a list of inputs with tickets (not from upstream).
+	InteractiveApps    InteractiveApps `json:"interactive_apps"`
+	InvocationID       string          `json:"uuid"`
+	IRODSBase          string          `json:"irods_base"`
+	Name               string          `json:"name"`
+	NFSBase            string          `json:"nfs_base"`
+	Notify             bool            `json:"notify"`
+	NowDate            string          `json:"now_date"`
+	OutputDir          string          `json:"output_dir"`         //the value parsed out of the JSON. Use OutputDirectory() instead.
+	OutputDirTicket    string          `json:"output_dir_ticket"`  //the write ticket for output_dir (assumes output_dir is set correctly).
+	OutputTicketFile   string          `json:"output_ticket_list"` //path to the file of the output dest with ticket (not from upstream).
+	RequestDisk        string          `json:"request_disk"`       //untested for now
+	RequestType        string          `json:"request_type"`
+	RunOnNFS           bool            `json:"run-on-nfs"`
+	SkipParentMetadata bool            `json:"skip-parent-meta"`
+	Steps              []Step          `json:"steps"`
+	SubmissionDate     string          `json:"submission_date"`
+	Submitter          string          `json:"username"`
+	Type               string          `json:"type"`
+	UserID             string          `json:"user_id"`
+	UserGroups         []string        `json:"user_groups"`
+	WikiURL            string          `json:"wiki_url"`
 }
 
 // New returns a pointer to a newly instantiated Job with NowDate set.

--- a/jobs.go
+++ b/jobs.go
@@ -57,50 +57,51 @@ func ExtractJobID(output []byte) []byte {
 
 // Job is a type that contains info that goes into the jobs table.
 type Job struct {
-	AppDescription         string         `json:"app_description"`
-	AppID                  string         `json:"app_id"`
-	AppName                string         `json:"app_name"`
-	ArchiveLogs            bool           `json:"archive_logs"`
-	ID                     string         `json:"id"`
-	BatchID                string         `json:"batch_id"`
-	CASAddr                string         `json:"cas_address"`
-	CondorID               string         `json:"condor_id"`
-	CondorLogPath          string         `json:"condor_log_path"` //comes from config, not upstream service
-	CreateOutputSubdir     bool           `json:"create_output_subdir"`
-	DateSubmitted          time.Time      `json:"date_submitted"`
-	DateStarted            time.Time      `json:"date_started"`
-	DateCompleted          time.Time      `json:"date_completed"`
-	Description            string         `json:"description"`
-	Email                  string         `json:"email"`
-	ExecutionTarget        string         `json:"execution_target"`
-	ExitCode               int            `json:"exit_code"`
-	FailureCount           int64          `json:"failure_count"`
-	FailureThreshold       int64          `json:"failure_threshold"`
-	FileMetadata           []FileMetadata `json:"file-metadata"`
-	FilterFiles            []string       `json:"filter_files"`       //comes from config, not upstream service
-	Group                  string         `json:"group"`              //untested for now
-	InputTicketsFile       string         `json:"inputs_ticket_list"` //path to a list of inputs with tickets (not from upstream).
-	InvocationID           string         `json:"uuid"`
-	IRODSBase              string         `json:"irods_base"`
-	Name                   string         `json:"name"`
-	NFSBase                string         `json:"nfs_base"`
-	Notify                 bool           `json:"notify"`
-	NowDate                string         `json:"now_date"`
-	OutputDir              string         `json:"output_dir"`         //the value parsed out of the JSON. Use OutputDirectory() instead.
-	OutputDirTicket        string         `json:"output_dir_ticket"`  //the write ticket for output_dir (assumes output_dir is set correctly).
-	OutputTicketFile       string         `json:"output_ticket_list"` //path to the file of the output dest with ticket (not from upstream).
-	OutwardFacingProxyAddr string         `json:"outward_facing_proxy_address"`
-	RequestDisk            string         `json:"request_disk"` //untested for now
-	RequestType            string         `json:"request_type"`
-	RunOnNFS               bool           `json:"run-on-nfs"`
-	SkipParentMetadata     bool           `json:"skip-parent-meta"`
-	Steps                  []Step         `json:"steps"`
-	SubmissionDate         string         `json:"submission_date"`
-	Submitter              string         `json:"username"`
-	Type                   string         `json:"type"`
-	UserID                 string         `json:"user_id"`
-	UserGroups             []string       `json:"user_groups"`
-	WikiURL                string         `json:"wiki_url"`
+	AppDescription         string          `json:"app_description"`
+	AppID                  string          `json:"app_id"`
+	AppName                string          `json:"app_name"`
+	ArchiveLogs            bool            `json:"archive_logs"`
+	ID                     string          `json:"id"`
+	BatchID                string          `json:"batch_id"`
+	CASAddr                string          `json:"cas_address"`
+	CondorID               string          `json:"condor_id"`
+	CondorLogPath          string          `json:"condor_log_path"` //comes from config, not upstream service
+	CreateOutputSubdir     bool            `json:"create_output_subdir"`
+	DateSubmitted          time.Time       `json:"date_submitted"`
+	DateStarted            time.Time       `json:"date_started"`
+	DateCompleted          time.Time       `json:"date_completed"`
+	Description            string          `json:"description"`
+	Email                  string          `json:"email"`
+	ExecutionTarget        string          `json:"execution_target"`
+	ExitCode               int             `json:"exit_code"`
+	FailureCount           int64           `json:"failure_count"`
+	FailureThreshold       int64           `json:"failure_threshold"`
+	FileMetadata           []FileMetadata  `json:"file-metadata"`
+	FilterFiles            []string        `json:"filter_files"`       //comes from config, not upstream service
+	Group                  string          `json:"group"`              //untested for now
+	InputTicketsFile       string          `json:"inputs_ticket_list"` //path to a list of inputs with tickets (not from upstream).
+	InteractionApps        InteractiveApps `json:"interactive_apps"`
+	InvocationID           string          `json:"uuid"`
+	IRODSBase              string          `json:"irods_base"`
+	Name                   string          `json:"name"`
+	NFSBase                string          `json:"nfs_base"`
+	Notify                 bool            `json:"notify"`
+	NowDate                string          `json:"now_date"`
+	OutputDir              string          `json:"output_dir"`         //the value parsed out of the JSON. Use OutputDirectory() instead.
+	OutputDirTicket        string          `json:"output_dir_ticket"`  //the write ticket for output_dir (assumes output_dir is set correctly).
+	OutputTicketFile       string          `json:"output_ticket_list"` //path to the file of the output dest with ticket (not from upstream).
+	OutwardFacingProxyAddr string          `json:"outward_facing_proxy_address"`
+	RequestDisk            string          `json:"request_disk"` //untested for now
+	RequestType            string          `json:"request_type"`
+	RunOnNFS               bool            `json:"run-on-nfs"`
+	SkipParentMetadata     bool            `json:"skip-parent-meta"`
+	Steps                  []Step          `json:"steps"`
+	SubmissionDate         string          `json:"submission_date"`
+	Submitter              string          `json:"username"`
+	Type                   string          `json:"type"`
+	UserID                 string          `json:"user_id"`
+	UserGroups             []string        `json:"user_groups"`
+	WikiURL                string          `json:"wiki_url"`
 }
 
 // New returns a pointer to a newly instantiated Job with NowDate set.

--- a/step.go
+++ b/step.go
@@ -19,23 +19,43 @@ type StepComponent struct {
 	Restricted  bool      `json:"restricted"`
 }
 
+// StepInteractiveConfig is where the tool specific interactive app settings are
+// located in the job definition.
+type StepInteractiveConfig struct {
+	// If websocket handling requires a special path in the app. The default is to
+	// have this be empty.
+	WebsocketPath string `json:"websocket_path"`
+
+	// If websocket handling requires a special port in the app. The default is to
+	// use the same port as the backend URL.
+	WebsocketPort string `json:"websocket_port"`
+
+	// If websocket handling requires a protocol other than ws://.
+	WebsocketProto string `json:"websocket_proto"`
+
+	// Only used if you need to override the default backendURL, which should be
+	// http://<container_name>.
+	BackendURL string `json:"backend_url"`
+}
+
 // StepEnvironment defines the environment variables that should be set for a
 // step
 type StepEnvironment map[string]string
 
 // Step describes a single step in a job. All jobs contain multiple steps.
 type Step struct {
-	Component     StepComponent
-	Config        StepConfig
-	Type          string          `json:"type"`
-	StdinPath     string          `json:"stdin"`
-	StdoutPath    string          `json:"stdout"`
-	StderrPath    string          `json:"stderr"`
-	LogFile       string          `json:"log-file"`
-	Environment   StepEnvironment `json:"environment"`
-	IsInteractive bool            `json:"is_interactive"`
-	Input         []StepInput     `json:"input"`
-	Output        []StepOutput    `json:"output"`
+	Component         StepComponent
+	Config            StepConfig
+	Type              string                `json:"type"`
+	StdinPath         string                `json:"stdin"`
+	StdoutPath        string                `json:"stdout"`
+	StderrPath        string                `json:"stderr"`
+	LogFile           string                `json:"log-file"`
+	Environment       StepEnvironment       `json:"environment"`
+	IsInteractive     bool                  `json:"is_interactive"`
+	InteractiveConfig StepInteractiveConfig `json:"interactive_config"`
+	Input             []StepInput           `json:"input"`
+	Output            []StepOutput          `json:"output"`
 }
 
 // EnvOptions returns a string containing the docker command-line options


### PR DESCRIPTION
We're going to have to configure some stuff for interactive apps at the top-level in Jobs and on a per-step basis. This pull request adds initial versions of both of those, which will be used by interapps-runner when it becomes available and should be ignorable by road-runner.

Information like the image used to pull down the reverse proxy, the proxy container name, the frontend URL, CAS settings, and SSL settings are the same for each step in the job, so they're configured in the InteractiveApps struct added to the top-level Jobs struct.

Websocket settings and possible the backend URL need to be configurable on a step-by-step basis, so they've been added to the StepInteractiveConfig struct that is located in the Step struct.