### PR TITLE
CORE-9192 Add Input Path List support to Job model

### DIFF
--- a/io.go
+++ b/io.go
@@ -63,17 +63,33 @@ func (i *StepInput) Source() string {
 	return value
 }
 
+// Returns the porklock settings needed for a get command with an input path list.
+func (j *Job) InputSourceListArguments(sourceListPath string) []string {
+	args := []string{
+		"get",
+		"--user", j.Submitter,
+		"--source-list", sourceListPath,
+	}
+
+	for _, m := range MetadataArgs(j.FileMetadata).FileMetadataArguments() {
+		args = append(args, m)
+	}
+
+	return args
+}
+
 // Arguments returns the porklock settings needed for the input operation.
 func (i *StepInput) Arguments(username string, metadata []FileMetadata) []string {
-	path := i.IRODSPath()
 	args := []string{
 		"get",
 		"--user", username,
-		"--source", path,
+		"--source", i.IRODSPath(),
 	}
+
 	for _, m := range MetadataArgs(metadata).FileMetadataArguments() {
 		args = append(args, m)
 	}
+
 	return args
 }
 

--- a/jobs.go
+++ b/jobs.go
@@ -76,10 +76,10 @@ type Job struct {
 	FailureCount       int64          `json:"failure_count"`
 	FailureThreshold   int64          `json:"failure_threshold"`
 	FileMetadata       []FileMetadata `json:"file-metadata"`
-	FilterFiles        []string       `json:"filter_files"`       //comes from config, not upstream service
-	Group              string         `json:"group"`              //untested for now
-	InputPathListFile  string         `json:"input_path_list"`    //path to a list of inputs (not from upstream).
-	InputTicketsFile   string         `json:"inputs_ticket_list"` //path to a list of inputs with tickets (not from upstream).
+	FilterFiles        []string       `json:"filter_files"`      //comes from config, not upstream service
+	Group              string         `json:"group"`             //untested for now
+	InputPathListFile  string         `json:"input_path_list"`   //path to a list of inputs (not from upstream).
+	InputTicketsFile   string         `json:"input_ticket_list"` //path to a list of inputs with tickets (not from upstream).
 	InvocationID       string         `json:"uuid"`
 	IRODSBase          string         `json:"irods_base"`
 	Name               string         `json:"name"`

--- a/jobs.go
+++ b/jobs.go
@@ -78,6 +78,7 @@ type Job struct {
 	FileMetadata       []FileMetadata `json:"file-metadata"`
 	FilterFiles        []string       `json:"filter_files"`       //comes from config, not upstream service
 	Group              string         `json:"group"`              //untested for now
+	InputPathListFile  string         `json:"input_path_list"`    //path to a list of inputs (not from upstream).
 	InputTicketsFile   string         `json:"inputs_ticket_list"` //path to a list of inputs with tickets (not from upstream).
 	InvocationID       string         `json:"uuid"`
 	IRODSBase          string         `json:"irods_base"`

--- a/jobs.go
+++ b/jobs.go
@@ -377,6 +377,18 @@ func (s *Job) UsesVolumes() bool {
 	return false
 }
 
+// Returns a list of inputs that do not have download tickets.
+func (job *Job) FilterInputsWithoutTickets() []StepInput {
+	var inputs []StepInput
+	for _, input := range job.Inputs() {
+		if input.Ticket == "" {
+			inputs = append(inputs, input)
+		}
+	}
+	return inputs
+}
+
+// Returns a list of inputs that have download tickets.
 func (job *Job) FilterInputsWithTickets() []StepInput {
 	var inputs []StepInput
 	for _, input := range job.Inputs() {


### PR DESCRIPTION
This PR will add an `InputPathListFile` field to the `Job` model, along with `FilterInputsNoTickets` and `InputSourceListArguments` support methods.

The new field and methods can be used by `condor-launcher` to create an input path list for Condor job submissions, then `road-runner` can create an appropriate input download command, according to the changes from cyverse-de/porklock#4, using the submitted input path list.